### PR TITLE
Fixed parsing issue with Long Description

### DIFF
--- a/pycaching/cache.py
+++ b/pycaching/cache.py
@@ -637,7 +637,7 @@ class Cache(object):
 
         user_content = root.find_all("div", "UserSuppliedContent")
         self.summary = user_content[0].text
-        self.description = str(user_content[1])
+        self.description = str(user_content[1].text)
 
         self.hint = rot13(root.find(id="div_hint").text.strip())
 


### PR DESCRIPTION
See #77

> If there is no long description for the cache listed on the website, cache.description returns
> 
> <div class="UserSuppliedContent">
> <span id="ctl00_ContentBody_LongDescription"></span>
> </div>
> 
> This should be handled gracefully, and just return an empty string. I will put in a pull request for this when I fix it.